### PR TITLE
[게시글] Post 엔티티 및 JPA 매핑

### DIFF
--- a/src/main/java/kr/kro/simpleboard/SimpleBoardApplication.java
+++ b/src/main/java/kr/kro/simpleboard/SimpleBoardApplication.java
@@ -2,7 +2,9 @@ package kr.kro.simpleboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SimpleBoardApplication {
 

--- a/src/main/java/kr/kro/simpleboard/global/domain/BaseAuditableEntity.java
+++ b/src/main/java/kr/kro/simpleboard/global/domain/BaseAuditableEntity.java
@@ -1,0 +1,30 @@
+package kr.kro.simpleboard.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseAuditableEntity extends BaseTimeEntity {
+
+
+    @CreatedBy
+    @Column(name = "CREATED_BY", updatable = false)
+    protected Long createdBy;
+
+    @LastModifiedBy
+    @Column(name = "UPDATED_BY")
+    protected Long updatedBy;
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public void setUpdatedBy(Long updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+}

--- a/src/main/java/kr/kro/simpleboard/global/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/kro/simpleboard/global/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package kr.kro.simpleboard.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "CREATED_AT", nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "UPDATED_AT")
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/kro/simpleboard/post/domain/Post.java
+++ b/src/main/java/kr/kro/simpleboard/post/domain/Post.java
@@ -1,0 +1,40 @@
+package kr.kro.simpleboard.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.kro.simpleboard.global.domain.BaseAuditableEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "SB_POST")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Post extends BaseAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private int views = 0;
+
+    @Column(nullable = false)
+    private int likes = 0;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     name: SimpleBoard
 
   datasource:
-#    url: jdbc:h2:tcp://localhost/~/simpleboard
-    url: jdbc:h2:mem:simpleboard
+    url: jdbc:h2:tcp://localhost/~/simpleboard
+#    url: jdbc:h2:mem:simpleboard
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
게시글 엔티티 설계 및 JPA 매핑 완료
- BaseAuditableEntity 상속
- createdAt, updatedAt 자동 처리
- createdBy, updatedBy는 수동 setter로 설정

Closes #2 